### PR TITLE
Fixed translation for Italian

### DIFF
--- a/Languages/Italian.csv
+++ b/Languages/Italian.csv
@@ -2079,7 +2079,7 @@ EGO,"",EGO
 Deal sneak attack damage when you charge.|Enemies with Uncanny Dodge are immune to this.,"",Fai danni da furtivo quando carichi.|I nemici dotati di Schivare Prodigioso sono immuni.
 Charm Person,"",Charm Persone
 Fears,"",Paure
-d00,"",d00
+d00,"",d
 LYCANTHROPIC EMPATHY,"",EMPATIA LICANTROPICA
 Acrobatics|Bonus,"",Bonus|Acrobazia
 Treat any jump check as if from a running start,"",Considera le prove di Saltare come con rincorsa


### PR DESCRIPTION
I've changed the `d00` -> `d00` to `d00` -> `d` translation for Italian language.